### PR TITLE
remove gem install from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,5 @@ before_install:
   - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 20;
   - sudo g++ --version;
   - sudo apt-get update -qq;
-  - gem install sass
   - npm install -g gulp bower
   - bower install


### PR DESCRIPTION
no longer needed due to https://github.com/base-apps/angular-base/pull/8
