### PR TITLE
Initializing state definitions with empty resolve object

### DIFF
--- a/js/angular/services/base.dynamicRouting.js
+++ b/js/angular/services/base.dynamicRouting.js
@@ -54,6 +54,7 @@
             controller: getController(page),
             data: getData(page),
             animation: buildAnimations(page),
+            resolve: {}
           };
 
           $stateProvider.state(page.name, state);


### PR DESCRIPTION
Initializing state definitions with empty resolve object so that resolves can be added within $stateChangeStart. This would make it possible to create middleware for states.
