### PR TITLE
adding gutters using block-spacing

### DIFF
--- a/docs/assets/scss/_examples.scss
+++ b/docs/assets/scss/_examples.scss
@@ -17,6 +17,7 @@
   }
 }
 
+
 .docs-grid-demo {
   height: 100px;
   margin: 0 0 1.5rem 0 !important;
@@ -29,6 +30,19 @@
     font-weight: bold;
     text-align: center;
   }
+
+  $block-spacing: 15px;
+  &.gutters {
+    height: auto;
+    background: rgba($primary-color, 0.1);
+    padding: $block-spacing/2;
+    &, .grid-block, .grid-content, .grid-container {
+      padding: $block-spacing/2;
+      margin: $block-spacing/2;
+      justify-content: center;
+    }
+  }
+
   .shrink {
     width: 100px;
   }
@@ -98,8 +112,8 @@
     font-size: 2rem;
     align-items: center;
     justify-content: center;
-    }
   }
+}
 
 .docs-example-dialog .modal {
   text-align: center;

--- a/docs/templates/grid.html
+++ b/docs/templates/grid.html
@@ -355,6 +355,111 @@ title: Grid
 
 <hr>
 
+<h4>Gutters</h4>
+
+<p>Use `gutters` class on your `grid-block` to apply `$global-spacing` to your columns. This will force the heigh of all columns in a row to be the same height while maintaining a consitant global spacing around all blocks. Helpful for adding backgrounds to widgets and panels.</p>
+
+<hljs language="html">
+<div class="grid-block gutters">
+  <div class="shrink grid-block">
+    Lots of content that will force this column to grow downward forcing the other columns in the row to fill negative space to maintain an equal height.
+  </div>
+  <div class="grid-block">
+    Very little content but will have same background height.
+  </div>
+</div>
+</hljs>
+
+<div class="docs-grid-demo grid-block gutters">
+  <div class="shrink grid-block">
+    Lots of content that will force this column to grow downward forcing the other columns in the row to fill negative space to maintain an equal height.
+  </div>
+  <div class="grid-block">
+    Very little content but will have same background height.
+  </div>
+</div>
+
+<h5>Gutters with manual sizing.</h5>
+
+<hljs language="html">
+<div class="grid-block gutters">
+  <div class="small-3 grid-block">
+      Lots of content that will force this column to grow downward forcing the other columns in the row to fill negative space to maintain an equal height.
+  </div>
+  <div class="small-3 grid-block">
+    Very little content but will have same background height.
+  </div>
+  <div class="small-6 grid-block">
+    Very little content but will have same background height.
+  </div>
+</div>
+</hljs>
+
+<div class="docs-grid-demo docs-grid-demo grid-block gutters">
+  <div class="small-3 grid-block">
+    Lots of content that will force this column to grow downward forcing the other columns in the row to fill negative space to maintain an equal height.
+  </div>
+  <div class="small-3 grid-block">
+    Very little content but will have same background height.
+  </div>
+  <div class="small-6 grid-block">
+    Very little content but will have same background height.
+  </div>
+</div>
+
+<h5>Gutters with wrapping.</h5>
+<p>Notice that all blocks maintain the same height as others siblings in the same row. This is a great solution to maintain styled background heights without the use of javascript.</p>
+
+<hljs language="html">
+<div class="grid-block gutters wrap">
+  <div class="small-3 grid-block">
+    Lots of content that will force this column to grow downward forcing the other blocks in this row to fill negative space to maintain an equal height.
+  </div>
+  <div class="small-9 grid-block">
+    Very little content but will have same background height.
+  </div>
+  <div class="small-6 grid-block">
+    Another block with less content but same desired height.
+  </div>
+  <div class="small-3 grid-block">
+    Another block with less content but same desired height.
+  </div>
+  <div class="small-3 grid-block">
+    Another block with lots of content but we will want the others in the row to have an equal height. 
+  </div>
+  <div class="small-6 grid-block">
+    The blocks in this row have equal sized content.
+  </div>
+  <div class="small-6 grid-block">
+    The blocks in this row have equal sized content.
+  </div>
+</div>
+</hljs>
+
+<div class="docs-grid-demo docs-grid-demo grid-block gutters wrap">
+  <div class="small-3 grid-block">
+    Lots of content that will force this column to grow downward farther so the other blocks will grow to maintain an equal height.
+  </div>
+  <div class="small-9 grid-block">
+    Very little content but will have same background height.
+  </div>
+  <div class="small-6 grid-block">
+    Another block with less content but same desired height.
+  </div>
+  <div class="small-3 grid-block">
+    Another block with less content but same desired height.
+  </div>
+  <div class="small-3 grid-block">
+    Another block with lots of content but we will want the others in the row to have an equal height. 
+  </div>
+  <div class="small-6 grid-block">
+    The blocks in this row have equal sized content.
+  </div>
+  <div class="small-6 grid-block">
+    The blocks in this row have equal sized content.
+  </div>
+</div>
+
 <h3>Building with Mixins</h3>
 
 <p>The grid has many features, and to create a robust responsive design you'll need to use many of them, often times on the same element. That can lead to HTML like this:</p>
@@ -488,6 +593,8 @@ title: Grid
 </hljs>
 
 <hr>
+
+
 
 <h3>Sass Variables</h3>
 

--- a/docs/templates/grid.html
+++ b/docs/templates/grid.html
@@ -460,6 +460,8 @@ title: Grid
   </div>
 </div>
 
+<hr>
+
 <h3>Building with Mixins</h3>
 
 <p>The grid has many features, and to create a robust responsive design you'll need to use many of them, often times on the same element. That can lead to HTML like this:</p>

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -235,6 +235,7 @@
 
 // $container-width: rem-calc(900);
 // $block-padding: $global-padding;
+// $block-spacing: $global-spacing;
 // $total-columns: 12;
 // $block-grid-max-size: 6;
 

--- a/scss/components/_grid.scss
+++ b/scss/components/_grid.scss
@@ -20,6 +20,7 @@
 // Grid
 $container-width: rem-calc(900) !default;
 $block-padding: $global-padding !default;
+$block-spacing: $global-spacing !default;
 $total-columns: 12 !default;
 $block-grid-max-size: 6 !default;
 ///
@@ -30,20 +31,36 @@ $block-grid-max-size: 6 !default;
   If set to "shrink", the block will contract and only fill as much space as it needs for its content.
 
   If set to a number, the block will be given a percentage width, based on the total number of columns (12 by default). Percentage widths don't work if a block is inside a vertical grid.
+  
+  If $gutter-width set to a number that is not "0", grid blocks will have "justify-content: space-between" like flex styles with a fixed space. 
 
   @group grid
 
   @param {number|string} $size - Sizing behavior of the block. Should be expand, shrink, or a number.
 
+  @param {number} $gutter-width - Size of fixed gutter to be added.
+
   @output The flex-basis, flex-grow, and flex-shrink properties.
 */
-@mixin grid-size($size: expand) {
-  @if (type-of($size) == 'number') {
+@mixin grid-size($size: expand, $gutter-width: 0) {
+
+  @if (type-of($size) == 'number' and strip-unit($gutter-width) != 0) {
     $pct: percentage($size / $total-columns);
+
+    // use calc to gutters between relative columns 
+    flex: 0 0 calc(#{$pct} - #{$gutter-width});
+    // max-width prevents columns from wrapping early in IE10/11
+    max-width: calc(#{$pct} - #{$gutter-width});
+  }
+
+  @else if (type-of($size) == 'number') {
+    $pct: percentage($size / $total-columns);
+
     flex: 0 0 $pct;
     // max-width prevents columns from wrapping early in IE10/11
     max-width: $pct;
   }
+
   @else if ($size == shrink) {
     flex: 0 0 auto;
     overflow: visible;
@@ -51,6 +68,7 @@ $block-grid-max-size: 6 !default;
   @else if ($size == expand) {
     flex: 1 1 auto;
   }
+
 }
 /*
   Set the orientation of blocks within this block. The grid is re-oriented by changing the flex direction of the block.
@@ -319,7 +337,20 @@ $block-grid-max-size: 6 !default;
   &.align-spaced  { @include grid-align(spaced); }
 
   // Allow child elements to wrap
-  &.wrap { @include grid-wrap(true); }
+  &.wrap { 
+    @include grid-wrap(true); 
+  }
+
+  // Allow for gutters
+  // Set negative margins on parent block to crop gutters of direct children
+  &.gutters {
+    margin: -($block-spacing/2);
+    // make wrap stretch for full hiegh column background
+    &.wrap {
+      align-items: stretch;
+    }
+  }
+
 }
 
 // Shared styles for blocks and content blocks (child elements)
@@ -329,6 +360,11 @@ $block-grid-max-size: 6 !default;
 
   // Prevent an element from scrolling
   &.noscroll { overflow: visible; }
+
+    // Add gutters to child blocks
+  .gutters > & {
+    margin: $block-spacing/2;
+  }
 }
 
 @include exports(grid) {
@@ -452,6 +488,10 @@ $block-grid-max-size: 6 !default;
         // Block sizing
         .#{$size}-#{$i} {
           @include grid-size($i);
+          // Block sizing with gutters
+          .gutters > & {
+            @include grid-size($i,$block-spacing);
+          }
         }
         // Source ordering
         .#{$size}-order-#{$i} {


### PR DESCRIPTION
Adding `.gutters` class to `grid-block` so that you can apply spacing between columns for easier implementation of `background` related styles requiring equal height. One of the benefits of flex is to maintain equal height columns that are dynamic based on content, but currently when using the Manual sizing grid there is no way to allow for gutters so you have to nest elements which impedes the ability to have full (`stretch`) height flex blocks/items. 

This will work for both manual and default flex grid and use the `$global-spacing` variable as `!default`.

When using `.wrap` with `.gutters` the `align-items` should be set to `stretch` and not `flex-start` so that the columns heights all have equal height. That update is included.
### Practical Examples

_Custom `.scss` to be shared by all practical examples below_

``` SCSS
.bg-fill-color {
    background-color: cyan;
}
```

**Flex grid**

``` HTML
<div class="grid-block gutters">
  <div class="shrink grid-block bg-fill-color">Hello</div>
  <div class="grid-block bg-fill-color">World</div>
</div>
```

**Manual Sizing grid**

``` HTML
<div class="grid-block gutters">
  <div class="grid-block small-6 medium-4 bg-fill-color">Hello</div>
  <div class="grid-block small-6 medium-8 bg-fill-color">World</div>
</div>
```

**Manual Sizing grid with wrap** 
Note: should use temp `.scss` shiv for `wrap` above

``` HTML
<div class="grid-block gutters wrap">
  <div class="grid-block small-12 medium-4 bg-fill-color">Hello</div>
  <div class="grid-block small-6 medium-8 bg-fill-color">Around</div>
  <div class="grid-block small-6 medium-6 bg-fill-color">the</div>
  <div class="grid-block small-12 medium-6 bg-fill-color">World</div>
</div>
```
### Updated Docs with Examples

`angular-base-apps/#!/grid`
