### PR TITLE
Fix baCloseAll with nested elements within a baOpen/etc. element

### DIFF
--- a/js/angular/components/common/common.js
+++ b/js/angular/components/common/common.js
@@ -201,9 +201,21 @@
       element.on('click', function(e) {
         var tar = e.target, avoid, activeElements, closedElements, i;
 
-        // check if clicked target is designated to open/close another component
+        // check if clicked target or any of its ancestors is designated to open/close
+        // another component
         avoid = ['ba-toggle', 'ba-hard-toggle', 'ba-open', 'ba-close'].filter(function(e){
-          return tar.closest('*[' + e + ']') !== null;
+          var parentElement = tar, hasAttr = false;
+
+          while (parentElement && typeof(parentElement.getAttribute) === 'function') {
+            var attrVal = parentElement.getAttribute(e);
+            if (typeof(attrVal) !== 'undefined' && attrVal !== null) {
+              hasAttr = true;
+              break;
+            }
+            parentElement = parentElement.parentNode;
+          }
+
+          return hasAttr;
         });
         if(avoid.length > 0) {
           // do nothing

--- a/js/angular/components/common/common.js
+++ b/js/angular/components/common/common.js
@@ -203,7 +203,7 @@
 
         // check if clicked target is designated to open/close another component
         avoid = ['ba-toggle', 'ba-hard-toggle', 'ba-open', 'ba-close'].filter(function(e){
-          return e in tar.attributes;
+          return tar.closest('*[' + e + ']') !== null;
         });
         if(avoid.length > 0) {
           // do nothing


### PR DESCRIPTION
Fix issue where, when using baCloseAll, clicking on a nested element
within a baOpen/baClose/baToggle element would not open the thing it
was supposed to open. When checking for a click on such an element,
check the element’s ancestry as well.

Fixes issue #85 

Tested on browsers:
Firefox (OSX, latest)
Chrome (OSX, latest)
IE11
Safari 10
Chrome, Firefox (Android)
Chrome, Safari (iOS)
